### PR TITLE
Github action for building and pushing repo image

### DIFF
--- a/.github/workflows/push_to_quay.yml
+++ b/.github/workflows/push_to_quay.yml
@@ -1,0 +1,53 @@
+name: Docker build control repo image and push to Quay
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      # Replace non-word branch name characters using the same method that R10k employs
+      - name: Normalize branch name
+        id: branchname
+        run: ruby -e "branch='${{ github.ref_name }}'.gsub(/\W/,'_'); puts \"NORMALIZED_BRANCH_NAME=#{branch}\"" >> $GITHUB_OUTPUT
+      - name: Set up Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/openinfra/holos-control-repo
+          tags: |
+            # Creates "branch-$SHA_SHORT" version tag
+            type=sha,enable=true,priority=100,prefix=${{steps.branchname.outputs.NORMALIZED_BRANCH_NAME}}-,suffix=,format=short
+            # Sets the latest tag for default branch pushes
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BRANCH=${{steps.branchname.outputs.NORMALIZED_BRANCH_NAME}}
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM busybox
+
+ARG BRANCH
+
+RUN mkdir -p "/etc/puppetlabs/code/environments/${BRANCH}"
+COPY . ./etc/puppetlabs/code/environments/${BRANCH}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+DOCKER_IMAGE_NAME := holos-control-repo
+DOCKER_IMAGE_TAG_VERSION := 0.1.0
+
+.PHONY: docker-build docker-run
+docker-build:
+	$(info Building Holos control repo image for branch: "$(BRANCH)")
+	docker build \
+		--build-arg BRANCH=${BRANCH} \
+		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_VERSION} .
+
+.PHONY: docker-run
+docker-run:
+	docker run --rm -it \
+	-v $(CURDIR):/workspace \
+	${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
+	/bin/sh


### PR DESCRIPTION
PROBLEM:

We need an automated way to build and push a container image of this
repo's contents for every branch update that's pushed. This will allow
us to attach that image to a running k8s pod and ultimately serve out
Puppet environments containint he code changes.

SOLUTION:

Use a GitHub action. Because this process is replacing R10k, we will
also need to handle non-word characters in branch/environment names.
This is being done using the same Ruby `gsub()` call that R10k uses for
compatibility.

OUTCOME:

Changes to any branch of this repo trigger an image build that gets
pushed to `quay.io`.
